### PR TITLE
Adding config to specify allowed inbound IP addresses

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -755,7 +755,9 @@ func assertManagedImageDataDiskSnapshotName(name, setting string) (bool, error) 
 func assertAllowedInboundIpAddresses(ipAddresses []string, setting string) (bool, error) {
 	for _, ipAddress := range ipAddresses {
 		if net.ParseIP(ipAddress) == nil {
-			return false, fmt.Errorf("The setting %s must only contain valid IP addresses", setting)
+			if _, _, err := net.ParseCIDR(ipAddress); err != nil {
+				return false, fmt.Errorf("The setting %s must only contain valid IP addresses or CIDR blocks", setting)
+			}
 		}
 	}
 	return true, nil

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"net"
 	"regexp"
 	"strings"
 	"time"
@@ -129,11 +130,12 @@ type Config struct {
 	TempResourceGroupName             string             `mapstructure:"temp_resource_group_name"`
 	BuildResourceGroupName            string             `mapstructure:"build_resource_group_name"`
 	storageAccountBlobEndpoint        string
-	PrivateVirtualNetworkWithPublicIp bool   `mapstructure:"private_virtual_network_with_public_ip"`
-	VirtualNetworkName                string `mapstructure:"virtual_network_name"`
-	VirtualNetworkSubnetName          string `mapstructure:"virtual_network_subnet_name"`
-	VirtualNetworkResourceGroupName   string `mapstructure:"virtual_network_resource_group_name"`
-	CustomDataFile                    string `mapstructure:"custom_data_file"`
+	PrivateVirtualNetworkWithPublicIp bool     `mapstructure:"private_virtual_network_with_public_ip"`
+	VirtualNetworkName                string   `mapstructure:"virtual_network_name"`
+	VirtualNetworkSubnetName          string   `mapstructure:"virtual_network_subnet_name"`
+	VirtualNetworkResourceGroupName   string   `mapstructure:"virtual_network_resource_group_name"`
+	AllowedInboundIpAddresses         []string `mapstructure:"allowed_inbound_ip_addresses"`
+	CustomDataFile                    string   `mapstructure:"custom_data_file"`
 	customData                        string
 	PlanInfo                          PlanInformation `mapstructure:"plan_info"`
 
@@ -673,6 +675,12 @@ func assertRequiredParametersSet(c *Config, errs *packer.MultiError) {
 		errs = packer.MultiErrorAppend(errs, fmt.Errorf("If virtual_network_subnet_name is specified, so must virtual_network_name"))
 	}
 
+	if c.AllowedInboundIpAddresses != nil && len(c.AllowedInboundIpAddresses) >= 1 {
+		if ok, err := assertAllowedInboundIpAddresses(c.AllowedInboundIpAddresses, "allowed_inbound_ip_addresses"); !ok {
+			errs = packer.MultiErrorAppend(errs, err)
+		}
+	}
+
 	/////////////////////////////////////////////
 	// Plan Info
 	if c.PlanInfo.PlanName != "" || c.PlanInfo.PlanProduct != "" || c.PlanInfo.PlanPublisher != "" || c.PlanInfo.PlanPromotionCode != "" {
@@ -740,6 +748,15 @@ func assertManagedImageOSDiskSnapshotName(name, setting string) (bool, error) {
 func assertManagedImageDataDiskSnapshotName(name, setting string) (bool, error) {
 	if !isValidAzureName(reSnapshotPrefix, name) {
 		return false, fmt.Errorf("The setting %s must only contain characters from a-z, A-Z, 0-9 and _ and the maximum length (excluding the prefix) is 60 characters", setting)
+	}
+	return true, nil
+}
+
+func assertAllowedInboundIpAddresses(ipAddresses []string, setting string) (bool, error) {
+	for _, ipAddress := range ipAddresses {
+		if net.ParseIP(ipAddress) == nil {
+			return false, fmt.Errorf("The setting %s must only contain valid IP addresses", setting)
+		}
 	}
 	return true, nil
 }

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -336,10 +336,10 @@ Providing `temp_resource_group_name` or `location` in combination with
     containing the virtual network. If the resource group cannot be found, or
     it cannot be disambiguated, this value should be set.
 
--   `allowed_inbound_ip_addresses` (array of strings) list of IP addresses that
-    should be allowed access to the VM. If provided, an Azure Network Security 
-    Group will be created with corresponding rules and be bound to the NIC 
-    attached to the VM. 
+-   `allowed_inbound_ip_addresses` (array of strings) list of IP addresses and
+    CIDR blocks that should be allowed access to the VM. If provided, an Azure
+    Network Security Group will be created with corresponding rules and be bound 
+    to the NIC attached to the VM. 
 
 -   `virtual_network_subnet_name` (string) If virtual\_network\_name is set,
     this value **may** also be set. If virtual\_network\_name is set, and this

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -336,6 +336,11 @@ Providing `temp_resource_group_name` or `location` in combination with
     containing the virtual network. If the resource group cannot be found, or
     it cannot be disambiguated, this value should be set.
 
+-   `allowed_inbound_ip_addresses` (array of strings) list of IP addresses that
+    should be allowed access to the VM. If provided, an Azure Network Security 
+    Group will be created with corresponding rules and be bound to the NIC 
+    attached to the VM. 
+
 -   `virtual_network_subnet_name` (string) If virtual\_network\_name is set,
     this value **may** also be set. If virtual\_network\_name is set, and this
     value is not set the builder attempts to determine the subnet to use with


### PR DESCRIPTION
This PR adds config change to allow specifying allowed inbound IP addresses.
[These IP addresses will be used to create an NSG in a separate PR].
Unit tests: Pass
Acceptance Tests: Not run