### PR TITLE
Ensuring that specifying allowed inbound IP and VNet are mutually exclusive

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -676,8 +676,12 @@ func assertRequiredParametersSet(c *Config, errs *packer.MultiError) {
 	}
 
 	if c.AllowedInboundIpAddresses != nil && len(c.AllowedInboundIpAddresses) >= 1 {
-		if ok, err := assertAllowedInboundIpAddresses(c.AllowedInboundIpAddresses, "allowed_inbound_ip_addresses"); !ok {
-			errs = packer.MultiErrorAppend(errs, err)
+		if c.VirtualNetworkName != "" {
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("If virtual_network_name is specified, allowed_inbound_ip_addresses cannot be specified"))
+		} else {
+			if ok, err := assertAllowedInboundIpAddresses(c.AllowedInboundIpAddresses, "allowed_inbound_ip_addresses"); !ok {
+				errs = packer.MultiErrorAppend(errs, err)
+			}
 		}
 	}
 

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -308,7 +308,6 @@ func TestConfigShouldAcceptCorrectInboundIpAddresses(t *testing.T) {
 		"subscription_id":        "ignore",
 		"os_type":                constants.Target_Linux,
 		"communicator":           "none",
-		"virtual_network_name":   "MyVirtualNetwork",
 	}
 
 	config["allowed_inbound_ip_addresses"] = ipValue0
@@ -355,7 +354,6 @@ func TestConfigShouldRejectIncorrectInboundIpAddresses(t *testing.T) {
 		"subscription_id":        "ignore",
 		"os_type":                constants.Target_Linux,
 		"communicator":           "none",
-		"virtual_network_name":   "MyVirtualNetwork",
 	}
 
 	config["allowed_inbound_ip_addresses"] = []string{"127.0.0.1", "127.0.0.two"}
@@ -369,6 +367,32 @@ func TestConfigShouldRejectIncorrectInboundIpAddresses(t *testing.T) {
 	if err == nil {
 		// 192.168.100.1000/24 is invalid
 		t.Errorf("Expected configuration creation to fail, but it succeeded with the malformed allowed_inbound_ip_addresses set to %v", c.AllowedInboundIpAddresses)
+	}
+}
+
+func TestConfigShouldRejectInboundIpAddressesWithVirtualNetwork(t *testing.T) {
+	config := map[string]interface{}{
+		"capture_name_prefix":          "ignore",
+		"capture_container_name":       "ignore",
+		"location":                     "ignore",
+		"image_url":                    "ignore",
+		"storage_account":              "ignore",
+		"resource_group_name":          "ignore",
+		"subscription_id":              "ignore",
+		"os_type":                      constants.Target_Linux,
+		"communicator":                 "none",
+		"allowed_inbound_ip_addresses": "127.0.0.1",
+	}
+
+	_, _, err := newConfig(config, getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config["virtual_network_name"] = "some_vnet_name"
+	_, _, err = newConfig(config, getPackerConfiguration())
+	if err == nil {
+		t.Errorf("Expected configuration creation to fail, but it succeeded with allowed_inbound_ip_addresses and virtual_network_name both specified")
 	}
 }
 

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -341,6 +341,9 @@ Providing `temp_resource_group_name` or `location` in combination with
     Network Security Group will be created with corresponding rules and be bound 
     to the NIC attached to the VM. 
 
+    Providing `allowed_inbound_ip_addresses` in combination with
+    `virtual_network_name` is not allowed.
+
 -   `virtual_network_subnet_name` (string) If virtual\_network\_name is set,
     this value **may** also be set. If virtual\_network\_name is set, and this
     value is not set the builder attempts to determine the subnet to use with


### PR DESCRIPTION
Ensuring that specifying allowed inbound IP and VNet are mutually exclusive